### PR TITLE
v0.6.1 Price field validation on LineItems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edi-translator",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "homepage": "https://trandrew1023.github.io/edi-translator",
   "private": true,
   "dependencies": {

--- a/src/components/LineItem.jsx
+++ b/src/components/LineItem.jsx
@@ -5,16 +5,19 @@ import {
   FormControl,
   Grid,
   IconButton,
+  InputAdornment,
   InputLabel,
   MenuItem,
   Select,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import PropTypes from 'prop-types';
 import { React, useState } from 'react';
 import poLineStatusCodes from '../static/data/poLineStatusCodes.json';
 import CommentModal from './CommentModal';
+import { InfoOutlined } from '@mui/icons-material';
 
 function LineItem({
   lineItem,
@@ -86,6 +89,15 @@ function LineItem({
           label="Price"
           value={lineItem.price}
           onChange={(event) => handleEventChange(event, 'price')}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <Tooltip title="must be a number" arrow>
+                  <InfoOutlined />
+                </Tooltip>
+              </InputAdornment>
+            )
+          }}
         />
       </Grid>
       <Grid item xs={4}>

--- a/src/components/PurchaseOrder.jsx
+++ b/src/components/PurchaseOrder.jsx
@@ -107,7 +107,7 @@ function PurchaseOrder() {
         });
       }
       //regex only accepts positive integers or decimal numbers up to 2 decimal places of precision [EX. 234, 12.8, 1.99, 15342523, 0.76]
-      if (!lineItem.price || !(/^[0-9]*\.[0-9]{1,2}$|^[0-9]+$/.test(lineItem.price))) {
+      if (!lineItem.price || !(/^[0-9]*(\.[0-9]{1,2})?$/.test(lineItem.price))) {
         checkLineItemErrors.set(key, {
           ...checkLineItemErrors.get(key),
           price: true,

--- a/src/components/PurchaseOrder.jsx
+++ b/src/components/PurchaseOrder.jsx
@@ -106,7 +106,8 @@ function PurchaseOrder() {
           orderedQuantity: true,
         });
       }
-      if (!lineItem.price) {
+      //regex only accepts positive integers or decimal numbers up to 2 decimal places of precision [EX. 234, 12.8, 1.99, 15342523, 0.76]
+      if (!lineItem.price || !(/^[0-9]*\.[0-9]{1,2}$|^[0-9]+$/.test(lineItem.price))) {
         checkLineItemErrors.set(key, {
           ...checkLineItemErrors.get(key),
           price: true,


### PR DESCRIPTION
- When handling the submit button in PurchaseOrder.jsx checks Price field for number
- Number must be a positive integer or decimal number up to 2 decimal places of precision [EX. 234, 12.8, 1.99, 15342523, 0.76]
- Resolves: #19 
![image](https://user-images.githubusercontent.com/94586121/215589252-9318ab5b-0c56-4136-8224-503b77fb8869.png)
![image](https://user-images.githubusercontent.com/94586121/215589492-15144b8f-f831-49bb-a2e6-55928d3edcd6.png)
![image](https://user-images.githubusercontent.com/94586121/215589324-57aef8a9-2cf2-4695-a4df-5d64d576a2c0.png)
![image](https://user-images.githubusercontent.com/94586121/215589403-76eb5e1b-ceae-4b3f-b978-e158296413b8.png)
