### PR TITLE
v0.8.1 Fix GitHub icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edi-translator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edi-translator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://trandrew1023.github.io/edi-translator",
   "private": true,
   "dependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -119,7 +119,7 @@ function App() {
           alignItems: 'center',
           bgcolor: 'background.default',
           color: 'text.primary',
-          minHeight: '100vh',
+          minHeight: '90vh',
           height: 'auto',
         }}
       >
@@ -132,15 +132,27 @@ function App() {
         >
           {renderFormSelect()}
           {renderForm()}
-          <IconButton
-            href="https://github.com/trandrew1023/edi-translator#readme"
-            sx={{
-              alignSelf: 'flex-end',
-            }}
-          >
-            <GitHubIcon />
-          </IconButton>
         </Grid>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          bgcolor: 'background.default',
+          color: 'text.primary',
+          minHeight: '10vh',
+          height: 'auto',
+        }}
+      >
+        <IconButton
+          href="https://github.com/trandrew1023/edi-translator#readme"
+          sx={{
+            alignSelf: 'flex-end',
+          }}
+        >
+          <GitHubIcon />
+        </IconButton>
       </Box>
     </ThemeProvider>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,15 +132,15 @@ function App() {
         >
           {renderFormSelect()}
           {renderForm()}
+          <IconButton
+            href="https://github.com/trandrew1023/edi-translator#readme"
+            sx={{
+              alignSelf: 'flex-end',
+            }}
+          >
+            <GitHubIcon />
+          </IconButton>
         </Grid>
-        <IconButton
-          href="https://github.com/trandrew1023/edi-translator#readme"
-          sx={{
-            alignSelf: 'flex-end',
-          }}
-        >
-          <GitHubIcon />
-        </IconButton>
       </Box>
     </ThemeProvider>
   );


### PR DESCRIPTION
Icon caused main Grid to shift left cause it was outside of the Grid